### PR TITLE
Fixed sklearn.svm import statement.

### DIFF
--- a/scikit_wrappers.py
+++ b/scikit_wrappers.py
@@ -2,6 +2,7 @@ import math
 import numpy
 import torch
 import sklearn
+import sklearn.svm
 
 import utils
 import losses


### PR DESCRIPTION
Submodules are not implicitly imported by the interpreter.