### PR TITLE
Fixed GPU-CPU tensor conversion bug. Fixed imports. Added compatibility with sklearn 0.20.1

### DIFF
--- a/scikit_wrappers.py
+++ b/scikit_wrappers.py
@@ -324,7 +324,7 @@ class TimeSeriesEncoderClassifier(sklearn.base.BaseEstimator,
                         batch = batch.cuda(self.gpu)
                     features[
                         count * batch_size: (count + 1) * batch_size
-                    ] = self.encoder(batch)
+                    ] = self.encoder(batch).cpu()
                     count += 1
             else:
                 for batch in test_generator:

--- a/scikit_wrappers.py
+++ b/scikit_wrappers.py
@@ -3,6 +3,9 @@ import numpy
 import torch
 import sklearn
 import sklearn.svm
+import sklearn.externals
+import sklearn.model_selection
+import joblib
 
 import utils
 import losses
@@ -88,7 +91,7 @@ class TimeSeriesEncoderClassifier(sklearn.base.BaseEstimator,
                '$(prefix_file)_$(architecture)_encoder.pth').
         """
         self.save_encoder(prefix_file)
-        sklearn.externals.joblib.dump(
+        joblib.dump(
             self.classifier,
             prefix_file + '_' + self.architecture + '_classifier.pkl'
         )


### PR DESCRIPTION
I am not sure if it is support of sklearn 0.20.1+ is desirable. However, changes should not break backward compatibility with sklearn 0.20.0.