### PR TITLE
Fixed GPU-CPU tensor conversion bug. Fixed imports. Added compatibility with sklearn 0.20.1

### DIFF
--- a/scikit_wrappers.py
+++ b/scikit_wrappers.py
@@ -321,7 +321,7 @@ class TimeSeriesEncoderClassifier(sklearn.base.BaseEstimator,
                         batch = batch.cuda(self.gpu)
                     features[
                         count * batch_size: (count + 1) * batch_size
-                    ] = self.encoder(batch)
+                    ] = self.encoder(batch).cpu()
                     count += 1
             else:
                 for batch in test_generator:
@@ -332,7 +332,7 @@ class TimeSeriesEncoderClassifier(sklearn.base.BaseEstimator,
                     ).data.cpu().numpy()
                     features[count: count + 1] = self.encoder(
                         batch[:, :, :length]
-                    )
+                    ).cpu()
                     count += 1
 
         self.encoder = self.encoder.train()

--- a/scikit_wrappers.py
+++ b/scikit_wrappers.py
@@ -3,6 +3,8 @@ import numpy
 import torch
 import sklearn
 import sklearn.svm
+import sklearn.externals
+import sklearn.model_selection
 
 import utils
 import losses


### PR DESCRIPTION
I am not sure if it is support of sklearn 0.20.1+ is desirable. However, changes should not break backward compatibility with sklearn 0.20.0.