### PR TITLE
Normalization in UEA dataset loading

### DIFF
--- a/uea.py
+++ b/uea.py
@@ -71,10 +71,10 @@ def load_UEA_dataset(path, dataset):
         for j in range(nb_dims):
             test[i, j] = time_series.get_instance(j).values
 
-    # Normalizing dimensions independently
+    # Normalizing dimensions independently (by column) and regarding mean and variance of the training data only
     for j in range(nb_dims):
-        mean = numpy.mean(numpy.concatenate([train[:, j], test[:, j]]))
-        var = numpy.var(numpy.concatenate([train[:, j], test[:, j]]))
+        mean = numpy.mean(train[:, j]))
+        var = numpy.var(train[:, j]))
         train[:, j] = (train[:, j] - mean) / math.sqrt(var)
         test[:, j] = (test[:, j] - mean) / math.sqrt(var)
 


### PR DESCRIPTION
Since we do not know whether training and test sets are truly representative samples from the whole population (hard to prove), it is IMHO common best practice to use the parameters (sample mean and -variance) of the training data only for normalization purpose, as long as there is no extra data set left for a final validation. Especially for small test sets, there could hypothetical be an irregular benefit for any later classifier otherwise (Although I don't think that there will be any recognizable change in the metrics here in case of UEA).

see also: https://stats.stackexchange.com/questions/77350/perform-feature-normalization-before-or-within-model-validation

Seems to be the same in case of ucr.py...